### PR TITLE
Add JSON export and clean feedback generator

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -1040,6 +1040,21 @@
             handleExportYAML(userName || 'default_user', setExportedYaml, true);
         };
 
+        // JSONエクスポート
+        const handleExportJSON = () => {
+            console.debug("handleExportJSON called.");
+            const snapshotsKey = `snapshots_${userName || 'default_user'}`;
+            const snapshots = JSON.parse(localStorage.getItem(snapshotsKey)) || [];
+            const exportData = { snapshots };
+            const jsonStr = JSON.stringify(exportData, null, 2);
+            const blob = new Blob([jsonStr], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'progress_backup.json';
+            link.click();
+        };
+
         // JSONインポート
         const handleImportJSONFile = (e) => {
             console.debug("handleImportJSONFile called with event:", e);
@@ -1183,6 +1198,7 @@
                         <div className={`collapsible-content ${showExportImport ? 'show' : ''}`}>
                             <button onClick={handleExportText}>テキストとしてエクスポートする</button>
                             <button onClick={handleExportPDF}>PDFとしてエクスポート</button>
+                            <button onClick={handleExportJSON}>JSONとしてエクスポート</button>
                             <div style={{ marginTop: '10px' }}>
                                 <label
                                     htmlFor="import-json"

--- a/feedback.js
+++ b/feedback.js
@@ -1381,47 +1381,6 @@ const encouragementPresets = {
     }
   }
   
-/**
- * フィードバック生成関数
- * 
- * @param {string} yamlInput - 評価データを含むYAML形式の文字列。
- * @returns {Object} フィードバック結果。成功時はフィードバックテキストを含み、エラー時はエラーメッセージを含む。
- */
-function createFeedbackFromYAML(yamlInput) {
-    try {
-        const parsedData = parseYAML(yamlInput);
-
-        // 「評価」部分を取り出してオブジェクトに変換
-        const evaluationArray = parsedData["評価"] || [];
-        const evaluationData = {};
-
-        evaluationArray.forEach(categoryObj => {
-            for (const category in categoryObj) {
-                if (categoryObj.hasOwnProperty(category)) {
-                    evaluationData[category] = categoryObj[category];
-                }
-            }
-        });
-
-        if (Object.keys(evaluationData).length === 0) {
-            return { success: false, message: "評価データが正しくありません。" };
-        }
-
-        // フィードバック生成
-        const feedbackText = generateFeedback(
-            evaluationData,
-            encouragementPresets,
-            improvementPresets
-        );
-
-        return { success: true, feedback: feedbackText };
-
-    } catch (error) {
-        console.error("Error generating feedback:", error);
-        return { success: false, message: "エラーが発生しました: " + error.message };
-    }
-}
-
   // モジュールとしてエクスポート（Node.jsの場合）
   if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
     module.exports = {

--- a/main.gs
+++ b/main.gs
@@ -10,9 +10,6 @@ function doGet(e) {
     if (fileName === 'script.js') {
       content = getScriptJS();
       mimeType = ContentService.MimeType.TEXT_PLAIN; // もしくは ContentService.MimeType.JAVASCRIPT
-    } else if (fileName === 'anotherScript.js') {
-            mimeType = ContentService.MimeType.TEXT_PLAIN;
-            return HtmlService.createHtmlOutputFromFile('Index');
     } else {
       // 不明なファイルリクエストの場合
       return HtmlService.createHtmlOutputFromFile('Index');
@@ -1426,47 +1423,6 @@ const encouragementPresets = {
     }
   }
   
-/**
- * フィードバック生成関数
- * 
- * @param {string} yamlInput - 評価データを含むYAML形式の文字列。
- * @returns {Object} フィードバック結果。成功時はフィードバックテキストを含み、エラー時はエラーメッセージを含む。
- */
-function createFeedbackFromYAML(yamlInput) {
-    try {
-        const parsedData = parseYAML(yamlInput);
-
-        // 「評価」部分を取り出してオブジェクトに変換
-        const evaluationArray = parsedData["評価"] || [];
-        const evaluationData = {};
-
-        evaluationArray.forEach(categoryObj => {
-            for (const category in categoryObj) {
-                if (categoryObj.hasOwnProperty(category)) {
-                    evaluationData[category] = categoryObj[category];
-                }
-            }
-        });
-
-        if (Object.keys(evaluationData).length === 0) {
-            return { success: false, message: "評価データが正しくありません。" };
-        }
-
-        // フィードバック生成
-        const feedbackText = generateFeedback(
-            evaluationData,
-            encouragementPresets,
-            improvementPresets
-        );
-
-        return { success: true, feedback: feedbackText };
-
-    } catch (error) {
-        console.error("Error generating feedback:", error);
-        return { success: false, message: "エラーが発生しました: " + error.message };
-    }
-}
-
   // モジュールとしてエクスポート（Node.jsの場合）
   if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
     module.exports = {


### PR DESCRIPTION
## Summary
- implement `handleExportJSON` and expose button in UI
- clean up duplicate `createFeedbackFromYAML` definition

## Testing
- `node build.js`


------
https://chatgpt.com/codex/tasks/task_e_6845086f11848321b5f4547862efd9d9